### PR TITLE
Add warning message for user when listing geo restricted material

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -154,6 +154,8 @@ class TV3PlayAddon(object):
                 url = streams['medium']
             elif 'low' in streams and streams['low'] is not None:
                 url = streams['low']
+            elif 'msg' in streams and streams['msg'] is not None:
+                return
             items.append((url, item))
 
         xbmcplugin.addSortMethod(HANDLE, xbmcplugin.SORT_METHOD_EPISODE)

--- a/mtgapi.py
+++ b/mtgapi.py
@@ -15,6 +15,7 @@ import urllib
 import urllib2
 try:
     import xbmc
+    import xbmcgui
 except:
     class xbmc(object):
         @staticmethod
@@ -59,6 +60,13 @@ class JsonApi(object):
             content = connection.read()
             connection.close()
             return content
+        except urllib2.HTTPError, e:
+            data = e.read()
+            reason = json.loads(data.decode('iso-8859-1').encode('utf-8'))
+            xbmcgui.Dialog().ok(("HTTP Error: " + str(e.code) + " " + e.reason),
+                                reason['msg'])
+            return data
+
         except Exception as ex:
             raise JsonApiException(ex)
 
@@ -225,7 +233,7 @@ class MtgApi(object):
         try:
             return data['streams']
         except:
-            return {}
+            return data
 
     @staticmethod
     def test():


### PR DESCRIPTION
Provides error message gotten as response from api while requesting a
stream not accessible in the current region.

Signed-off-by: Tomas Melin <tomas.melin@iki.fi>