### PR TITLE
set ListItem info type attribute to 'video'

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -99,10 +99,12 @@ class TV3PlayAddon(object):
         seasons = self.api.get_seasons(seasons_url)
 
         for season in seasons:
-            fanart = season['_links']['image']['href'].format(size='500x500')
-
-            item = xbmcgui.ListItem(season['title'], iconImage=fanart)
-            item.setProperty('Fanart_Image', fanart)
+            item = xbmcgui.ListItem(season['title'])
+            if 'image' in season['_links']:
+                fanart = season['_links']['image']['href'].format(size='500x500')
+                item.setProperty('Fanart_Image', fanart)
+                item.setIconImage(fanart)
+                
             url = self._build_url({'episodes_url': season['_links']['videos']['href']})
             xbmcplugin.addDirectoryItem(HANDLE,
                                         url,

--- a/addon.py
+++ b/addon.py
@@ -109,7 +109,12 @@ class TV3PlayAddon(object):
         seasons = self.api.get_seasons(seasons_url)
 
         for season in seasons:
+            infoLabels = {
+                'title': season['title'],
+                'plot': season.get('season_summary', '')
+            }
             item = xbmcgui.ListItem(season['title'])
+            item.setInfo('video', infoLabels)
             if 'image' in season['_links']:
                 fanart = season['_links']['image']['href'].format(size='500x500')
                 item.setProperty('Fanart_Image', fanart)

--- a/addon.py
+++ b/addon.py
@@ -136,7 +136,7 @@ class TV3PlayAddon(object):
             info_labels = {
                 'title': episode['title'],
                 'studio': ADDON.getAddonInfo('name'),
-                'plot': episode['description'],
+                'plot': episode['description'] or episode['summary'],
                 'plotoutline': episode['summary'],
                 'tvshowtitle': episode['format_title']
             }

--- a/addon.py
+++ b/addon.py
@@ -111,8 +111,10 @@ class TV3PlayAddon(object):
         for season in seasons:
             infoLabels = {
                 'title': season['title'],
-                'plot': season.get('season_summary', '')
+                'plot': season.get('season_summary', ''),
+                'date': _convert_date(season.get('updated_at', ''))
             }
+
             item = xbmcgui.ListItem(season['title'])
             item.setInfo('video', infoLabels)
             if 'image' in season['_links']:
@@ -126,6 +128,7 @@ class TV3PlayAddon(object):
                                         item, True)
 
         xbmcplugin.addSortMethod(HANDLE, xbmcplugin.SORT_METHOD_TITLE)
+        xbmcplugin.addSortMethod(HANDLE, xbmcplugin.SORT_METHOD_DATE)
         xbmcplugin.endOfDirectory(HANDLE)
 
     def listEpisodes(self, episodes_url):

--- a/addon.py
+++ b/addon.py
@@ -36,6 +36,14 @@ import time
 
 from mtgapi import MtgApi, MtgApiException
 
+
+def _convert_date(s):
+    if s:
+        return '%s.%s.%s' % (s[8:10], s[5:7], s[0:4])
+    else:
+        return ''
+
+
 class TV3PlayAddon(object):
     def __init__(self, region):
         self.region = region
@@ -85,6 +93,9 @@ class TV3PlayAddon(object):
                 #'plot': show['description']
             }
 
+            if 'updated_at' in show:
+                infoLabels['date'] = _convert_date(show['updated_at'])
+
             item = xbmcgui.ListItem(show['title'], iconImage=fanart)
             item.setInfo('video', infoLabels)
             item.setProperty('Fanart_Image', fanart)
@@ -93,6 +104,7 @@ class TV3PlayAddon(object):
 
         xbmcplugin.addDirectoryItems(HANDLE, items)
         xbmcplugin.addSortMethod(HANDLE, xbmcplugin.SORT_METHOD_TITLE)
+        xbmcplugin.addSortMethod(HANDLE, xbmcplugin.SORT_METHOD_DATE)
         xbmcplugin.endOfDirectory(HANDLE)
 
     def listSeasons(self, seasons_url):
@@ -134,7 +146,7 @@ class TV3PlayAddon(object):
             if 'broadcasts' in episode:
                 if 'air_at' in episode['broadcasts'] and episode['broadcasts']['air_at'] is not None:
                     airdate = episode['air_at']
-                    info_labels['date'] = '%s.%s.%s' % (airdate[8:10], airdate[5:7], airdate[0:4])
+                    info_labels['date'] = _convert_date(airdate)
                     info_labels['year'] = int(airdate[0:4])
 
             if 'format_position' in episode:

--- a/addon.py
+++ b/addon.py
@@ -87,15 +87,13 @@ class TV3PlayAddon(object):
 
         for show in shows:
             fanart = show['image']
-
             infoLabels = {
-                'title': show['title']
-                #'plot': show['description']
+                'title': show['title'],
+                'plot': show.get('description', '') or show.get('summary', ''),
+                'plotoutline': show.get('summary', ''),
+                'date': _convert_date(show.get('updated_at', ''))
             }
-
-            if 'updated_at' in show:
-                infoLabels['date'] = _convert_date(show['updated_at'])
-
+            
             item = xbmcgui.ListItem(show['title'], iconImage=fanart)
             item.setInfo('video', infoLabels)
             item.setProperty('Fanart_Image', fanart)

--- a/addon.py
+++ b/addon.py
@@ -141,7 +141,7 @@ class TV3PlayAddon(object):
                         info_labels['episode'] = int(episode['episode'])
 
             item = xbmcgui.ListItem(episode['title'], iconImage=fanart)
-            item.setInfo('episode', info_labels)
+            item.setInfo('video', info_labels)
             item.setProperty('IsPlayable', 'true')
             item.setProperty('Fanart_Image', fanart)
 

--- a/mtgapi.py
+++ b/mtgapi.py
@@ -67,7 +67,7 @@ class MtgApi(object):
     API implementation for the MTG tv services
     """
 
-    CONFIG_URL = "http://playapi.mtgx.tv/v3/config/{channel}"
+    CONFIG_URL = "https://playapi.mtgx.tv/v3/config/{channel}"
     CHANNELS_URL = "https://playapi.mtgx.tv/v3/channels?country={country}"
     ROOT_CHANNELS = {'no': 1550,
                      'se': 1209,

--- a/mtgapi.py
+++ b/mtgapi.py
@@ -68,6 +68,7 @@ class MtgApi(object):
     """
 
     CONFIG_URL = "http://playapi.mtgx.tv/v3/config/{channel}"
+    CHANNELS_URL = "https://playapi.mtgx.tv/v3/channels?country={country}"
     ROOT_CHANNELS = {'no': 1550,
                      'se': 1209,
                      'dk': 3687,
@@ -97,15 +98,9 @@ class MtgApi(object):
         """
         Returns a dict of channels. Key is id, value is name
         """
-        formats = next(view for view in self._config['views'] if view['name'] == 'formats')
-        channels = formats['filters']['channels']
-        ret = {}
-        for channel in channels:
-            if ',' in channel['value']:
-                continue
-            ret[channel['value']] = channel['name']
-
-        return ret
+        chlist = self._json_api.call(MtgApi.CHANNELS_URL, {'country': self._region})
+        return {ch['id']: ch['name']
+                for ch in chlist['_embedded']['channels']}
 
     def get_channel_icon(self, channel_id):
         """

--- a/mtgapi.py
+++ b/mtgapi.py
@@ -149,6 +149,9 @@ class MtgApi(object):
                                        {'channels': ','.join(channel_id),
                                         'categories': ''})
 
+            if '_embedded' not in data:
+                break
+            
             for show in data['_embedded']['formats']:
                 shows.append(show)
 


### PR DESCRIPTION
According to the python API [documentation](https://codedocs.xyz/AlwinEsch/kodi/group__python__xbmcgui__listitem.html#ga0b71166869bda87ad744942888fb5f14), the ListItem info type must be one of _video_, _music_, _pictures_ or _game_. This is enforced as of kodi v18, hence this patch fixes the plugin for more recent versions of kodi.

Fixes #7 (tested in kodi 18.2 and 17.6).